### PR TITLE
Fixed issue #21 - added validator

### DIFF
--- a/pages/models.py
+++ b/pages/models.py
@@ -1,11 +1,24 @@
 from __future__ import unicode_literals
 
 from django.db import models
+from django.core.exceptions import ValidationError
+
+def validate_legal_url(value):
+    RESTRICTED_URLS = [
+        'base',
+        'shows',
+        'login',
+        'dj',
+        'show',
+    ]
+    for url in RESTRICTED_URLS:
+        if str(value).startswith(url):
+            raise ValidationError('Urls starting with {} are not allowed'.format(url))
 
 # Create your models here.
 class Page(models.Model):
 	pageTitle = models.CharField(max_length=20, verbose_name='Page Title (Will be displayed on site')
-	pageURL = models.CharField(max_length=50, verbose_name='Page URL (http://kvrx.org/PAGEURL)')
+	pageURL = models.CharField(max_length=50, verbose_name='Page URL (http://kvrx.org/PAGEURL)', validators=[validate_legal_url])
 	pageContent = models.TextField(verbose_name='Page Content (HTML). Will be placed inside the standard KVRX template')
 	showOnHomepage = models.BooleanField(verbose_name='Show on home page?')
 	def __unicode__(self):


### PR DESCRIPTION
Added a validator that will not pass if the url starts with a reserved url. This needs to use `startswith` rather than an exact match since the urls.py will route extended urls as well. E.g:`/showsabc` will route to `/shows`.

I was unsure where users created pages however this fix will stop anyone from creating these pages at the urls via the `/admin/` interface.